### PR TITLE
Pass in event key for e2e tests' track call

### DIFF
--- a/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/PreCheckoutViewController.m
+++ b/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/PreCheckoutViewController.m
@@ -179,7 +179,9 @@ typedef NS_ENUM(NSInteger, UITableViewDiscountGiftCardSection) {
             }
             break;
         case UITableViewSectionContinue:
-            [self.optlyClient track:@"pre_checkout_cta_clicked" userId:self.userId attributes:self.userAttributes];
+            NSString *cartCTAEventKey = [[NSUserDefaults standardUserDefaults] stringForKey:@"optlyCartCtaEventKey"];
+
+            [self.optlyClient track:cartCTAEventKey userId:self.userId attributes:self.userAttributes];
             [self proceedToCheckout];
             break;
         default:


### PR DESCRIPTION
Allows us to pass in the event key for the pre-checkout track call, allowing us to test invalid event keys